### PR TITLE
Deploy Rust documentation to GitHub Pages

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,50 @@
+name: Build and deploy Rust documentation
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and deploy documentation
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+        name: Check out the repository
+
+      - uses: actions/configure-pages@v3
+        name: Setup GitHub Pages
+
+      - uses: ./.github/actions/prepare_rust/
+        name: Prepare Rust toolchain
+
+      - run: cargo doc --no-deps
+        name: Build the documentation
+
+      - run: chmod -c -R +rX 'target/doc'
+        name: Fix file permissions
+        shell: sh
+
+      - uses: actions/upload-pages-artifact@v1
+        name: Upload GitHub Pages artifact
+        with:
+          path: 'target/doc/'
+
+      - uses: actions/deploy-pages@v2
+        name: Deploy to GitHub Pages
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ The deployment manager for the PaaSTech Platform-as-a-Service.
 
 This service manages deploying applications for the PaaS clients in an execution engine, such as Docker or Kubernetes.
 
+Documentation is available [here](https://paastech-cloud.github.io/pomegranate/pomegranate/).
+
 ## Run this application
 To run Pomegranate, you must first [install the Rust toolchain](https://www.rust-lang.org/tools/install) for your platform.
 


### PR DESCRIPTION
# Overview

This adds a CI workflow on pushes to `main` to build and deploy the documentation for this project to GitHub pages.

# What's new?

- A CI workflow has been added that is automatically ran on pushes to the `main` branch, or by triggering it manually. This workflow builds the doc with `cargo doc` for only the binary crate. GitHub Pages is then set up and the generated documentation is deployed to it. Generated documentation is made available through an artifact.
- The README file has been updated to link to the GitHub Pages.

# Task list
- [X] Add the CI workflow
- [X] Build the doc in the workflow using cargo
- [X] Push the doc to GitHub pages using an action
- [X] Update the README to add a link to the doc

# Other stuff

Note: it was necessary to fix the permissions of the generated documentation because uploading to GitHub Pages was failing otherwise.
