### PR TITLE
Don't pull the container image when starting an application

### DIFF
--- a/src/engine/docker_engine.rs
+++ b/src/engine/docker_engine.rs
@@ -4,12 +4,12 @@ use bollard::container::{
     Config, CreateContainerOptions, InspectContainerOptions, LogsOptions, RemoveContainerOptions,
     StartContainerOptions, StatsOptions, StopContainerOptions,
 };
-use bollard::image::{CreateImageOptions, RemoveImageOptions};
+use bollard::image::RemoveImageOptions;
 use bollard::network::ConnectNetworkOptions;
 use bollard::service::{ContainerStateStatusEnum, EndpointSettings};
 use bollard::Docker;
 use bytes::Bytes;
-use futures::stream::{BoxStream, TryStreamExt};
+use futures::stream::BoxStream;
 use futures::StreamExt;
 use log::{info, trace};
 use std::collections::HashMap;
@@ -63,32 +63,6 @@ impl DockerEngine {
 #[async_trait]
 impl Engine for DockerEngine {
     async fn start_application(&self, app: &Application) -> Result<()> {
-        // Create the image
-        trace!(
-            "Pulling container image: {}:{}",
-            app.image_name,
-            app.image_tag
-        );
-
-        self.docker
-            .create_image(
-                Some(CreateImageOptions {
-                    from_image: app.image_name.clone(),
-                    tag: app.image_tag.clone(),
-                    ..Default::default()
-                }),
-                None,
-                None,
-            )
-            .try_collect::<Vec<_>>()
-            .await
-            .with_context(|| {
-                format!(
-                    "Failed to create the image for application {}/{}",
-                    app.project_id, app.application_id
-                )
-            })?;
-
         // Create the Docker container configuration
         let options = Some(CreateContainerOptions {
             name: Self::build_container_name(&app.project_id, &app.application_id),


### PR DESCRIPTION
# Overview
This PR fixes the current behavior of the `start_application` method, which always attempts to pull the image of the application from a container registry.
Because we currently only run images that are built to the local Docker image cache, and don't need any image from the outside, we can safely remove the image pull operation (otherwise, the function would return an error because it can't pull the image of a PaaS application that is not supposed to be on a registry anyway).

We shall decide how to pull images once we implement 3rd-party applications (such as Postgres) or we have a real image registry.

# What's new?
- Container images are no longer pulled automatically when starting a PaaS application.

# Task list
- [X] Remove the call to `create_image`

# Other stuff
Nothing.