### PR TITLE
Feat: Fallback when traefik isn't there

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,4 @@
-POMEGRANATE_FQDN=passtech.cloud  # Or localhost for dev
+POMEGRANATE_FQDN=localhost  # The fqdn, eg: passtech.cloud
 POMEGRANATE_DOCKER_NETWORK_NAME=pomegranate-proxy-network  # Name of the proxy network, common between Traefik and other containers
 POMEGRANATE_LETSENCRYPT_EMAIL=example@gmail.com  # The email address of the domain name administrator
 POMEGRANATE_LETSENCRYPT_PROVIDER=porkbun  # The DNS provider name, see https://doc.traefik.io/traefik/https/acme/#providers

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,4 @@ $RECYCLE.BIN/
 # End of https://www.toptal.com/developers/gitignore/api/rust,intellij+all,macos,windows,vim,linux,visualstudiocode
 
 .env
+letsencrypt/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,21 @@ This service manages deploying applications for the PaaS clients in an execution
 
 Documentation is available [here](https://paastech-cloud.github.io/pomegranate/pomegranate/).
 
-## Run this application
+## Try the project out with compose
+
+```bash
+$> cp .env.sample .env
+$> docker compose up --build
+```
+
+Pomegranate's gRPC server will then run on `[::]:50051`. The server will then answer to the proto routes defined at [paastech/proto](https://github.com/paastech-cloud/proto).
+
+By default, the deployed apps are available under `<project_id>.user-app.localhost`
+
+> ⚠️ Pomegranate only pulls images from the **local docker registry** !
+
+## Run this application separatly
+
 To run Pomegranate, you must first [install the Rust toolchain](https://www.rust-lang.org/tools/install) for your platform.  
 You must then install [protoc](https://grpc.io/docs/protoc-installation/), the Protocol Buffers compiler.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       # So that Traefik can listen to the Docker events
       - /var/run/docker.sock:/var/run/docker.sock
       # Uncomment to enable storage of Let's encrypt certificates on host
-      #- ./letsencrypt:/letsencrypt
+      - ./letsencrypt:/letsencrypt
     command:
       - --providers.docker=true
       - --providers.docker.network=pomegranate-proxy-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,8 @@ services:
     volumes:
       # So that Traefik can listen to the Docker events
       - /var/run/docker.sock:/var/run/docker.sock
-      # Let's encrypt certificates
-      - ./letsencrypt:/letsencrypt
+      # Uncomment to enable storage of Let's encrypt certificates on host
+      #- ./letsencrypt:/letsencrypt
     command:
       - --providers.docker=true
       - --providers.docker.network=pomegranate-proxy-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,5 +50,6 @@ services:
       - pomegranate-proxy-network
 
 networks:
+  # The network to connect client containers to traefik
   pomegranate-proxy-network:
     name: ${POMEGRANATE_DOCKER_NETWORK_NAME}

--- a/src/config/traefik_config.rs
+++ b/src/config/traefik_config.rs
@@ -15,7 +15,7 @@ impl TraefikConfig {
         TraefikConfig {
             fqdn: std::env::var("POMEGRANATE_FQDN").unwrap_or(String::from("localhost")),
             network_name: std::env::var("POMEGRANATE_DOCKER_NETWORK_NAME")
-                .expect("Missing proxy network !"),
+                .unwrap_or(String::from("traefik-fallback-network")),
         }
     }
 }

--- a/src/engine/docker_engine.rs
+++ b/src/engine/docker_engine.rs
@@ -44,9 +44,9 @@ impl DockerEngine {
         let config = ApplicationConfig::from_env();
 
         // Create the network if needed
-        let mut filters: HashMap<&str, Vec<&str>> = HashMap::new();
-        filters.insert("name", vec![&config.traefik_config.network_name]);
-        let list_options: ListNetworksOptions<&str> = ListNetworksOptions { filters };
+        let list_options: ListNetworksOptions<&str> = ListNetworksOptions {
+            filters: HashMap::from([("name", vec![config.traefik_config.network_name.as_ref()])]),
+        };
 
         let result_networks = docker.list_networks(Some(list_options)).await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn error::Error>> {
     );
 
     // Init the Docker engine
-    let engine = DockerEngine::new();
+    let engine = DockerEngine::new().await;
 
     grpc_server::start_server(engine).await.map_err(|e| {
         error!("Failed to start gRPC server: {}", e);


### PR DESCRIPTION
# Overview
This PR allows Pomegranate to fallback on a default network when not run with traefik/docker compose

# What's new?
Nothing I guess.

# Task list
- [ ] Delete the network when killing the process ?
